### PR TITLE
Refactor: useContext

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,12 +5,10 @@ import Container from '@material-ui/core/Container';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
-import { encrypt } from './utils/index'
 import Shift from './Shift';
 import PlainText from './PlainText';
 import EncryptedText from './EncryptedText';
-
-const { useReducer } = React;
+import { StateProvider } from './context/app';
 
 type ThemeObject = {
     spacing: (number) => string,
@@ -45,99 +43,36 @@ const makeStylesCb = (theme: ThemeObject) : useStylesObject => ({
     },
 })
 
-
 const useStyles: useStylesFunction = makeStyles(makeStylesCb);
-
-const initialState = {
-    shift: 0,
-    text: '',
-    encrypted: '',
-};
-
-// Actions
-const SHIFT_UPDATE = 'SHIFT_UPDATE';
-const TEXT_UPDATE = 'TEXT_UPDATE';
-const ENCRYPTED_UPDATE = 'ENCRYPTED_UPDATE';
-
-// Reducer
-const reducer = (state, action) => {
-    switch(action.type) {
-        case SHIFT_UPDATE:
-            const { shift } = action.payload;
-            return { shift, text: '', encrypted: ''};
-        case TEXT_UPDATE:
-            const { text } = action.payload;
-            return { ...state, text };
-        case ENCRYPTED_UPDATE:
-            const { encrypted } = action.payload;
-            return { ...state, encrypted };
-        default:
-            return {...state};
-    }
-};
-
-// Action Creators
-const updateShift = (shift) => ({
-    type: SHIFT_UPDATE,
-    payload: { shift },
-});
-
-const updateText = (text) => ({
-    type: TEXT_UPDATE,
-    payload: { text },
-});
-
-const updateEncrypted = (encrypted) => ({
-    type: ENCRYPTED_UPDATE,
-    payload: { encrypted }
-});
-
 
 function App(): React.Node {
     const classes = useStyles();
-    const [state, dispatch] = useReducer(reducer, initialState);
-    const { text, encrypted, shift } = state;
-
-    const handleDeltaChange = (e: SyntheticInputEvent<HTMLSelectElement>) : void => {
-        const value = Number.parseInt(e.target.value, 10);
-        dispatch(updateShift(value))
-    };
-
-    const handleTextChange = (e: SyntheticInputEvent<HTMLInputElement>) : void => {
-        const { value } = e.target;
-        dispatch(updateText(value))
-        dispatch(updateEncrypted(encrypt(value, shift)));
-    };
-
-    const handleEncryptedChange = (e: SyntheticInputEvent<HTMLInputElement>) : void => {
-        const { value } = e.target;
-        dispatch(updateEncrypted(value));
-        dispatch(updateText(encrypt(value, shift)));
-    };
 
     return (
-        <Container size="sm">
-            <Typography align="center" component="h1" variant="h2" gutterBottom>
-                Caesar Cipher
-            </Typography>
-            <Grid container spacing={3}>
-                <Grid item xs={12}>
-                    <Paper className={classes.delta} elevation={0}>
-                        <Shift value={shift} onChange={handleDeltaChange}/>
-                    </Paper>
+        <StateProvider>
+            <Container size="sm">
+                <Typography align="center" component="h1" variant="h2" gutterBottom>
+                    Caesar Cipher
+                </Typography>
+                <Grid container spacing={3}>
+                    <Grid item xs={12}>
+                        <Paper className={classes.delta} elevation={0}>
+                            <Shift />
+                        </Paper>
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <Paper className={classes.paper} elevation={0}>
+                            <PlainText /> 
+                        </Paper>
+                    </Grid>
+                    <Grid item xs={12} sm={6}>
+                        <Paper className={classes.paper} elevation={0}>
+                            <EncryptedText />
+                        </Paper>
+                    </Grid>
                 </Grid>
-                <Grid item xs={12} sm={6}>
-                    <Paper className={classes.paper} elevation={0}>
-                        <PlainText value={text} onChange={handleTextChange}/> 
-                    </Paper>
-                </Grid>
-                <Grid item xs={12} sm={6}>
-                    <Paper className={classes.paper} elevation={0}>
-                        <EncryptedText value={encrypted} onChange={handleEncryptedChange}/>
-                    </Paper>
-                </Grid>
-            </Grid>
-        </Container>
+            </Container>
+        </StateProvider>
   );
 }
 

--- a/src/EncryptedText.js
+++ b/src/EncryptedText.js
@@ -1,22 +1,29 @@
 /* @flow */
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
+import { useAppState, updateEncrypted, updateText } from './context/app';
+import { encrypt } from './utils/index';
 
-type Props = {
-    value: string,
-    onChange: <T>(SyntheticInputEvent<HTMLInputElement>) => void
-}
 
-const shouldUpdate = (prevProps: Props, nextProps: Props) : bool => prevProps.value === nextProps.value;
+const EncryptedText = () => {
+    const [state, dispatch] = useAppState();
+    const { encrypted, shift } = state;
 
-const EncryptedText = ({value, onChange}: Props) => (
-    <TextField
-        id="encrypted"
-        name="encrypted"
-        label="Encrypted Text"
-        value={value}
-        onChange={onChange}
-        fullWidth />
-);
+    const onChange = (e: SyntheticInputEvent<HTMLInputElement>) : void => {
+        const { value } = e.target;
+        dispatch(updateEncrypted(value));
+        dispatch(updateText(encrypt(value, shift)));
+    };
 
-export default React.memo<Props>(EncryptedText, shouldUpdate)
+    return ( 
+        <TextField
+            id="encrypted"
+            name="encrypted"
+            label="Encrypted Text"
+            value={encrypted}
+            onChange={onChange}
+            fullWidth />
+    );
+ };
+
+export default EncryptedText;

--- a/src/PlainText.js
+++ b/src/PlainText.js
@@ -1,22 +1,28 @@
 /* @flow */
 import * as React from 'react';
 import TextField from '@material-ui/core/TextField';
+import { encrypt } from './utils/index';
+import { useAppState, updateText, updateEncrypted } from './context/app';
 
-type Props = {
-    value: string,
-    onChange: <T>(SyntheticInputEvent<HTMLInputElement>) => void
-}
+const PlainText = () => { 
+    const [state, dispatch] = useAppState();
+    const { text, shift } = state;
 
-const shouldUpdate = (prevProps: Props, nextProps: Props) : bool => prevProps.value === nextProps.value;
+    const onChange = (e: SyntheticInputEvent<HTMLInputElement>) : void => {
+        const { value } = e.target;
+        dispatch(updateText(value))
+        dispatch(updateEncrypted(encrypt(value, shift)));
+    };
 
-const PlainText = ({value, onChange}: Props) => (
-    <TextField
+    return (
+        <TextField
         id="plain"
         name="plain"
         label="Plain Text"
-        value={value}
+        value={text}
         onChange={onChange}
         fullWidth />
-);
+    );
+ };
 
-export default React.memo<Props>(PlainText, shouldUpdate)
+export default PlainText;

--- a/src/Shift.js
+++ b/src/Shift.js
@@ -5,34 +5,39 @@ import InputLabel from '@material-ui/core/InputLabel';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
+import { useAppState, updateShift } from './context/app'
 
-const shiftValues = [...Array(24).keys()];
+const shiftValues = [...Array(25).keys()];
 
-type Props = {
-    value: number,
-    onChange: <T>(SyntheticInputEvent<HTMLSelectElement>) => void,
-}
 
-const shouldUpdate = (prevProps: Props, nextProps: Props) : bool => prevProps.value === nextProps.value;
+const Shift = () => {
+    const [state, dispatch] = useAppState();
+    const { shift } = state;
 
-const Shift = ({value, onChange}: Props) => (
-    <FormControl>
-        <InputLabel htmlFor="delta">Delta</InputLabel>
-        <Select
-            id="delta"
-            name="delta"
-            value={value}
-            onChange={onChange}
-        >
-            <MenuItem value={0}>
-                <em>None</em>
-            </MenuItem>
-            {shiftValues.map((idx) => (
-                <MenuItem key={idx} value={idx + 1}>{idx + 1}</MenuItem>
-            ))}
-        </Select>
-        <FormHelperText>How many letters to shift.</FormHelperText>
-    </FormControl>
-);
+    const onChange = (e: SyntheticInputEvent<HTMLSelectElement>) : void => {
+        const value = Number.parseInt(e.target.value, 10);
+        dispatch(updateShift(value))
+    };
 
-export default React.memo<Props>(Shift, shouldUpdate);
+    return (
+        <FormControl>
+            <InputLabel htmlFor="delta">Delta</InputLabel>
+            <Select
+                id="delta"
+                name="delta"
+                value={shift}
+                onChange={onChange}
+            >
+                <MenuItem value={0}>
+                    <em>None</em>
+                </MenuItem>
+                {shiftValues.map((idx) => (
+                    <MenuItem key={idx} value={idx + 1}>{idx + 1}</MenuItem>
+                ))}
+            </Select>
+            <FormHelperText>How many letters to shift.</FormHelperText>
+        </FormControl>
+    );
+ };
+
+export default Shift;

--- a/src/context/app.js
+++ b/src/context/app.js
@@ -1,0 +1,94 @@
+/* @flow */
+import * as React from 'react';
+
+const { createContext, useReducer } = React;
+
+type Action = { type: 'SHIFT_UPDATE', payload: { shift: number} } | { type: 'TEXT_UPDATE', payload: { text: string} } | { type: 'ENCRYPTED_UPDATE', payload: { encrypted: string } };
+type State = { shift: number, text: string, encrypted: string };
+type Dispatch = (action: Action) => void
+type StateProviderProps = { children: React.Node }
+
+const initialState: State = {
+    shift: 0,
+    text: '',
+    encrypted: '',
+};
+
+const StateContext = createContext<State | void>(undefined);
+const StateDispatchContext = createContext<Dispatch | void>(undefined);
+
+
+// Actions
+const SHIFT_UPDATE = 'SHIFT_UPDATE';
+const TEXT_UPDATE = 'TEXT_UPDATE';
+const ENCRYPTED_UPDATE = 'ENCRYPTED_UPDATE';
+
+// Action Creators
+const updateShift = (shift: number) => ({
+    type: SHIFT_UPDATE,
+    payload: { shift },
+});
+
+const updateText = (text: string) => ({
+    type: TEXT_UPDATE,
+    payload: { text },
+});
+
+const updateEncrypted = (encrypted: string) => ({
+    type: ENCRYPTED_UPDATE,
+    payload: { encrypted }
+});
+
+// Reducer
+const reducer = (state: State, action: Action) => {
+    switch(action.type) {
+        case SHIFT_UPDATE:
+            const { shift } = action.payload;
+            return { shift, text: '', encrypted: ''};
+        case TEXT_UPDATE:
+            const { text } = action.payload;
+            return { ...state, text };
+        case ENCRYPTED_UPDATE:
+            const { encrypted } = action.payload;
+            return { ...state, encrypted };
+        default:
+            return {...state};
+    }
+};
+
+const StateProvider = ({ children } : StateProviderProps) => {
+    const [state, dispatch] = useReducer<State, Action>(reducer, initialState);
+    return (
+        <StateContext.Provider value={state}>
+            <StateDispatchContext.Provider value={dispatch}>
+                {children}
+            </StateDispatchContext.Provider>
+        </StateContext.Provider>
+    )
+};
+
+const useAppStateContext = () => {
+    const context = React.useContext(StateContext);
+    if (context === undefined) {
+        throw new Error('useAppState must be used within a StateProvider');
+    }
+    return context;
+};
+
+const useAppDispatchContext = () => {
+    const context = React.useContext(StateDispatchContext);
+    if (context === undefined) {
+        throw new Error('useAppDispatch must be used withint a StateProvider');
+    }
+    return context;
+};
+
+const useAppState = () => [useAppStateContext, useAppDispatchContext];
+
+export {
+    useAppState,
+    StateProvider,
+    updateShift,
+    updateText,
+    updateEncrypted,
+}

--- a/src/context/app.js
+++ b/src/context/app.js
@@ -83,7 +83,7 @@ const useAppDispatchContext = () => {
     return context;
 };
 
-const useAppState = () => [useAppStateContext, useAppDispatchContext];
+const useAppState = () => [useAppStateContext(), useAppDispatchContext()];
 
 export {
     useAppState,


### PR DESCRIPTION
Following this [blog post](https://kentcdodds.com/blog/how-to-use-react-context-effectively), I went ahead and refactored the functionality to grab the values from `Context`.

It eliminates the need to pass properties into the different components.
It grabs values from the state that lives in the `Context`. 
It moves the handling of changing values closer to the component that are responsible for displaying those values.

⚠️ This implementation does not prevent a re-render of components that do not need to update (e.g. `<Shift/>` while typing in `<PlainText/>` or `<EncryptedText/>`.