### PR TITLE
Feat: Decrypt

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -111,8 +111,9 @@ function App(): React.Node {
 
     const handleEncryptedChange = (e: SyntheticInputEvent<HTMLInputElement>) : void => {
         const { value } = e.target;
+        const unshift = (26 - shift) % 26;
         dispatch(updateEncrypted(value));
-        dispatch(updateText(encrypt(value, shift)));
+        dispatch(updateText(encrypt(value, unshift)));
     };
 
     return (


### PR DESCRIPTION
Completes decrypt functionality. When decrypting a message we want to work backwards, so we subtract the shift from the 26 letters to get an offset and that can be used to map to a new letter.

:link: https://en.wikipedia.org/wiki/Caesar_cipher#Example

> Decrypt is performed similarly,
![decrypt](https://wikimedia.org/api/rest_v1/media/math/render/svg/8ed607e0202ff8d35aa41559f846cac9d358a362)